### PR TITLE
Remove \Altis\register_class_path reference

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -9,8 +9,6 @@
 
 namespace DisableAccounts;
 
-\Altis\register_class_path( __NAMESPACE__, __DIR__ . '/inc' );
-
 require __DIR__ . '/inc/namespace.php';
 
 bootstrap();


### PR DESCRIPTION
Fixes #5.

- `\Altis\register_class_path()` is not defined locally or through a Composer dependency.

- There are no class files under `./inc` so the `\Altis\register_class_path()` currently does nothing. It can be replaced with Composer classmap autoload once the actual class files are added under `./inc`.